### PR TITLE
Adjust Checkbox Hint API

### DIFF
--- a/app/components/flowbite/input_field/checkbox.rb
+++ b/app/components/flowbite/input_field/checkbox.rb
@@ -11,19 +11,15 @@ module Flowbite
 
       protected
 
-      # Returns the HTML to use for the hint element if any
-      def hint
-        return unless hint?
+      def default_hint_options
+        return {} unless @hint
 
-        component = Flowbite::Input::Hint.new(
-          attribute: @attribute,
-          form: @form,
-          options: {
-            class: hint_classes,
-            id: id_for_hint_element
-          }
-        ).with_content(@hint)
-        render(component)
+        hint_options = @hint.dup
+        hint_options.delete(:content)
+        {
+          class: hint_classes,
+          id: id_for_hint_element
+        }.merge(hint_options[:options] || {})
       end
 
       # Returns the HTML to use for the label element

--- a/test/components/input_field/checkbox_test.rb
+++ b/test/components/input_field/checkbox_test.rb
@@ -38,16 +38,31 @@ class Flowbite::InputField::CheckboxTest < Minitest::Test
   end
 
   def test_renders_a_hint
-    render_inline(Flowbite::InputField::Checkbox.new(form: @form, attribute: :subscribed, hint: "Check to receive updates"))
+    render_inline(Flowbite::InputField::Checkbox.new(form: @form, attribute: :subscribed, hint: {content: "Check to receive updates"}))
 
     assert_selector("p.text-xs.font-normal.text-gray-500", text: "Check to receive updates")
   end
 
+  def test_passes_options_to_the_hint
+    render_inline(Flowbite::InputField::Checkbox.new(form: @form, attribute: :subscribed, hint: {content: "Check to receive updates", options: {title: "Hint"}}))
+
+    assert_selector("p[title='Hint'].text-xs.font-normal.text-gray-500", text: "Check to receive updates")
+  end
+
   def test_adds_aria_attributes_for_hint
-    render_inline(Flowbite::InputField::Checkbox.new(form: @form, attribute: :subscribed, hint: "Check to receive updates"))
+    render_inline(Flowbite::InputField::Checkbox.new(form: @form, attribute: :subscribed, hint: {content: "Check to receive updates"}))
 
     assert_selector("input[aria-describedby='user_subscribed_hint']")
     assert_selector("p#user_subscribed_hint", text: "Check to receive updates")
+  end
+
+  def test_replaces_the_hint_entirely
+    render_inline(Flowbite::InputField::Checkbox.new(form: @form, attribute: :subscribed)) do |component|
+      component.with_hint { "This is the full hint" }
+    end
+
+    refute_selector("p.text-xs.font-normal.text-gray-500")
+    assert_text("This is the full hint")
   end
 
   def test_passes_input_options_to_input_element


### PR DESCRIPTION
Hints for Checkboxes should adhere to the same API as other hints and slot-based elements.