### PR TITLE
Fix class argument not adding to input class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-* `:class` arguments are now forwarded correctly to hint elements in Flowbite::InputField. If passed as `:class` it adds to the existing class names, if passed in `options[:class]` the existing class attribute is replaced.
+* `:class` arguments to subcomponents (ie `hint` and `input`) of Flowbite::InputField are now forwarded correctly. If passed as `:class` the given value is added to the existing class names, if passed in `options[:class]` the existing class attribute is replaced.
 
 
 ## [0.2.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* `:class` arguments are now forwarded correctly to hint elements in Flowbite::InputField. If passed as `:class` it adds to the existing class names, if passed in `options[:class]` the existing class attribute is replaced.
+
 
 ## [0.2.0]
 

--- a/app/components/flowbite/input_field.rb
+++ b/app/components/flowbite/input_field.rb
@@ -155,9 +155,7 @@ module Flowbite
       return unless hint?
 
       component = Flowbite::Input::Hint.new(
-        attribute: @attribute,
-        form: @form,
-        options: default_hint_options
+        **hint_arguments
       ).with_content(default_hint_content)
       render(component)
     end
@@ -225,6 +223,20 @@ module Flowbite
     # Returns true if the input field is disabled, false otherwise.
     def disabled?
       !!@disabled
+    end
+
+    # @return [Hash] The keyword arguments for the hint component.
+    def hint_arguments
+      {
+        attribute: @attribute,
+        class: @hint[:class],
+        form: @form,
+        options: hint_options
+      }
+    end
+
+    def hint_options
+      default_hint_options.merge(@hint[:options] || {})
     end
 
     # Returns true if the input field has a hint, false otherwise.

--- a/app/components/flowbite/input_field.rb
+++ b/app/components/flowbite/input_field.rb
@@ -258,6 +258,7 @@ module Flowbite
     def input_arguments
       {
         attribute: @attribute,
+        class: @input[:class],
         disabled: @disabled,
         form: @form,
         options: input_options,

--- a/app/components/flowbite/input_field.rb
+++ b/app/components/flowbite/input_field.rb
@@ -155,9 +155,19 @@ module Flowbite
       return unless hint?
 
       component = Flowbite::Input::Hint.new(
-        **hint_arguments
+        **default_hint_arguments
       ).with_content(default_hint_content)
       render(component)
+    end
+
+    # @return [Hash] The keyword arguments for the hint component.
+    def default_hint_arguments
+      {
+        attribute: @attribute,
+        class: @hint[:class],
+        form: @form,
+        options: default_hint_options
+      }
     end
 
     def default_hint_content
@@ -178,23 +188,37 @@ module Flowbite
       }.merge(@hint[:options] || {})
     end
 
+    # @return [Hash] The keyword arguments for the default input component.
+    def default_input_arguments
+      {
+        attribute: @attribute,
+        class: @input[:class],
+        disabled: @disabled,
+        form: @form,
+        options: default_input_options,
+        size: @size
+      }
+    end
+
     # Returns a Hash with the default attributes to apply to the input element.
     #
     # The default attributes can be overriden by passing the `input[options]`
     # argument to the constructor.
     def default_input_options
-      if hint?
+      options = if hint?
         {
           "aria-describedby": id_for_hint_element
         }
       else
         {}
       end
+
+      options.merge(@input[:options] || {})
     end
 
     # Returns the HTML to use for the default input element.
     def default_input
-      render(input_component.new(**input_arguments))
+      render(input_component.new(**default_input_arguments))
     end
 
     def default_label
@@ -225,20 +249,6 @@ module Flowbite
       !!@disabled
     end
 
-    # @return [Hash] The keyword arguments for the hint component.
-    def hint_arguments
-      {
-        attribute: @attribute,
-        class: @hint[:class],
-        form: @form,
-        options: hint_options
-      }
-    end
-
-    def hint_options
-      default_hint_options.merge(@hint[:options] || {})
-    end
-
     # Returns true if the input field has a hint, false otherwise.
     def hint?
       @hint.present?
@@ -252,22 +262,6 @@ module Flowbite
       ]
         .compact_blank
         .join("_")
-    end
-
-    # @return [Hash] The keyword arguments for the input component.
-    def input_arguments
-      {
-        attribute: @attribute,
-        class: @input[:class],
-        disabled: @disabled,
-        form: @form,
-        options: input_options,
-        size: @size
-      }
-    end
-
-    def input_options
-      default_input_options.merge(@input[:options] || {})
     end
   end
 end

--- a/app/components/flowbite/input_field.rb
+++ b/app/components/flowbite/input_field.rb
@@ -188,6 +188,11 @@ module Flowbite
       }.merge(@hint[:options] || {})
     end
 
+    # Returns the HTML to use for the default input element.
+    def default_input
+      render(input_component.new(**default_input_arguments))
+    end
+
     # @return [Hash] The keyword arguments for the default input component.
     def default_input_arguments
       {
@@ -214,11 +219,6 @@ module Flowbite
       end
 
       options.merge(@input[:options] || {})
-    end
-
-    # Returns the HTML to use for the default input element.
-    def default_input
-      render(input_component.new(**default_input_arguments))
     end
 
     def default_label

--- a/app/components/flowbite/input_field/checkbox.rb
+++ b/app/components/flowbite/input_field/checkbox.rb
@@ -31,19 +31,19 @@ module Flowbite
 
       private
 
+      def default_input_arguments
+        args = super
+        args[:unchecked_value] = @input[:unchecked_value] if @input.key?(:unchecked_value)
+        args[:value] = @input[:value] if @input.key?(:value)
+        args
+      end
+
       def hint_classes
         if disabled?
           "text-xs font-normal text-fg-disabled"
         else
           "text-xs font-normal text-body"
         end
-      end
-
-      def input_arguments
-        args = super
-        args[:unchecked_value] = @input[:unchecked_value] if @input.key?(:unchecked_value)
-        args[:value] = @input[:value] if @input.key?(:value)
-        args
       end
 
       def label_classes

--- a/app/components/flowbite/input_field/select.rb
+++ b/app/components/flowbite/input_field/select.rb
@@ -19,7 +19,7 @@ module Flowbite
             form: @form,
             include_blank: @include_blank,
             multiple: @multiple,
-            options: input_options,
+            options: default_input_options,
             size: @size
           )
         )

--- a/test/components/flowbite/input_field_test.rb
+++ b/test/components/flowbite/input_field_test.rb
@@ -352,4 +352,42 @@ class Flowbite::InputFieldWithoutObjectTest < Minitest::Test
 
     assert_selector("div[data-controller='input-field']")
   end
+
+  def test_adds_classes_to_label_element
+    render_inline(Flowbite::InputField.new(form: @form, attribute: :title, label: {class: "custom-label"}))
+
+    assert_selector("label[for='title'].text-sm.custom-label")
+  end
+
+  def test_overwrites_classes_on_label_element
+    render_inline(Flowbite::InputField.new(form: @form, attribute: :title, label: {options: {class: "custom-label"}}))
+
+    assert_selector("label[class='custom-label'][for='title']")
+  end
+
+  def test_adds_classes_to_hint_element
+    render_inline(Flowbite::InputField.new(form: @form, attribute: :title, hint: {class: "custom-hint", content: "Helpful hint"}))
+
+    assert_selector("p.text-sm.text-body.custom-hint")
+  end
+
+  def test_overwrites_classes_on_hint_element
+    render_inline(Flowbite::InputField.new(form: @form, attribute: :title, hint: {content: "Helpful hint", options: {class: "custom-hint"}}))
+
+    assert_selector("p[class='custom-hint']")
+  end
+
+  def test_adds_classes_to_input_element
+    render_inline(Flowbite::InputField.new(form: @form, attribute: :title, input: {class: "custom-input"}))
+
+    assert_selector("input[name=title].border.rounded-base")
+  end
+
+  def test_overwrites_classes_on_input_element
+    render_inline(Flowbite::InputField.new(form: @form, attribute: :title, input: {options: {class: "custom-input"}}))
+
+    assert_selector("input[name=title]") do |input|
+      assert_equal("custom-input", input[:class])
+    end
+  end
 end

--- a/test/components/flowbite/input_field_test.rb
+++ b/test/components/flowbite/input_field_test.rb
@@ -380,14 +380,12 @@ class Flowbite::InputFieldWithoutObjectTest < Minitest::Test
   def test_adds_classes_to_input_element
     render_inline(Flowbite::InputField.new(form: @form, attribute: :title, input: {class: "custom-input"}))
 
-    assert_selector("input[name=title].border.rounded-base")
+    assert_selector("input[name=title].border.rounded-base.custom-input")
   end
 
   def test_overwrites_classes_on_input_element
     render_inline(Flowbite::InputField.new(form: @form, attribute: :title, input: {options: {class: "custom-input"}}))
 
-    assert_selector("input[name=title]") do |input|
-      assert_equal("custom-input", input[:class])
-    end
+    assert_selector("input[name=title][class='custom-input']")
   end
 end


### PR DESCRIPTION
When passing values to the `class` argument of input, ie

    render(Flowbite::InputField::Text.new(..., input: {class: "adds-to-classes"})`

the resulting HTML should include

```html
<input ... class="<all the existing CSS class names> adds-to-classes" ...>
```

This allows the consumer to add extra classes to the input without having to recreate the entire class list. 

On the other hand, if the consumer wants to replace the entire class list, the `class` attribute can be set via `options`:

    render(Flowbite::InputField::Text.new(..., input: {options: {class: "replaces-classes"}})`

which results in 

```html
<input ... class="replaces-classes" ...>
```

which is usually not what you'd want, but there might be cases.

This behavior is consistent with using `Flowbite::Input::*` components directly. 